### PR TITLE
抽取公共环境变量，增加一个新的关于默认水印的环境变量;调整侧边栏设定按钮文案和图标

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+VITE_APP_TITLE=Lithe Admin
+VITE_APP_NAME=Lithe Admin
+VITE_DEFAULT_WATERMARK=Lithe Admin

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
+# 开发环境配置
 VITE_APP_TITLE=Development
-VITE_APP_NAME=Lithe Admin

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,1 @@
-VITE_APP_TITLE=Lithe Admin
-VITE_APP_NAME=Lithe Admin
+# 生产环境配置

--- a/src/layout/header/action/PreferencesDrawer.vue
+++ b/src/layout/header/action/PreferencesDrawer.vue
@@ -114,9 +114,9 @@ const showNoiseModal = () => {
   <div>
     <ButtonAnimation
       @click="showPreferencesDrawer = true"
-      title="侧边栏"
+      title="系统设定"
     >
-      <span class="iconify rotate-180 ph--sidebar-simple-duotone" />
+      <span class="iconify-[carbon--settings] rotate-180" />
     </ButtonAnimation>
     <ButtonAnimationProvider>
       <NDrawer

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -52,7 +52,7 @@ export const DEFAULT_PREFERENCES_OPTIONS = {
   enableNavigationTransition: true,
   enableTextSelect: true,
   watermarkOptions: {
-    content: 'Watermark',
+    content: import.meta.env.VITE_DEFAULT_WATERMARK || '',
     fontColor: '#D81E1E96',
     fontSize: 16,
     width: 384,

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,8 +1,15 @@
 /// <reference types="vite/client" />
 
+/**
+ * 环境变量类型定义
+ */
 interface ImportMetaEnv {
-  readonly VITE_APP_TITLE: string
+  /** 应用名称 */
   readonly VITE_APP_NAME: string
+  /** 应用标题 */
+  readonly VITE_APP_TITLE: string
+  /** 默认水印内容 */
+  readonly VITE_DEFAULT_WATERMARK: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
### 关于环境变量

在大多数情况下，VITE_APP_TITLE,VITE_APP_NAME,VITE_DEFAULT_WATERMARK都是不需要变更的，实际开发中更多的是base path、axios之类的配置需要跟随环境变量进行变更，因此抽取公共环境变量避免重复定义

### 关于图标
目前，设定项已经不仅仅是导航和布局等有关侧边栏的设置，还包括了主题颜色、水印、磨砂效果等非侧边栏设置，因此翻译成首选项或者系统设置之类的更合适，最终选取了与弹窗一致的系统设定作为按钮文案