### PR TITLE
feat: add directory structure file and update directory display in About view

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:check": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format:check": "prettier --check src/",
-    "format:fix": "prettier --write src/"
+    "format:fix": "prettier --write src/",
+    "tree": "npx --yes tree-node-cli -a -L 5 -F -I 'node_modules|.git|.DS_Store|dist|.output|.idea|.vscode' > src/views/about/dir.txt"
   },
   "dependencies": {
     "@vueuse/core": "^13.6.0",

--- a/src/views/about/dir.txt
+++ b/src/views/about/dir.txt
@@ -1,0 +1,157 @@
+lithe-admin/
+├── .deepsource.toml
+├── .editorconfig
+├── .env
+├── .env.development
+├── .env.production
+├── .prettierrc.json
+├── LICENSE
+├── README.en_US.md
+├── README.md
+├── eslint.config.ts
+├── index.html
+├── package.json
+├── public/
+│   ├── assets/
+│   │   └── preloader.css
+│   └── favicon.ico
+├── src/
+│   ├── App.vue
+│   ├── assets/
+│   │   ├── base.css
+│   │   ├── main.css
+│   │   ├── noise.png
+│   │   ├── texture.png
+│   │   └── topography.svg
+│   ├── components/
+│   │   ├── AppLogo.vue
+│   │   ├── Noise.vue
+│   │   ├── UserAvatar.vue
+│   │   ├── UserDropdown.vue
+│   │   ├── button-animation/
+│   │   │   ├── ButtonAnimation.test.ts
+│   │   │   ├── ButtonAnimation.vue
+│   │   │   ├── ButtonAnimationProvider.vue
+│   │   │   ├── index.ts
+│   │   │   ├── injection.ts
+│   │   │   └── interface.ts
+│   │   ├── collapse-transition/
+│   │   │   ├── CollapseTransition.test.ts
+│   │   │   └── CollapseTransition.vue
+│   │   ├── empty-placeholder/
+│   │   │   ├── EmptyPlaceholder.test.ts
+│   │   │   └── EmptyPlaceholder.vue
+│   │   ├── hint-help/
+│   │   │   ├── HintHelp.test.ts
+│   │   │   └── HintHelp.vue
+│   │   ├── index.ts
+│   │   └── scroll-container/
+│   │       ├── ScrollContainer.test.ts
+│   │       └── ScrollContainer.vue
+│   ├── composables/
+│   │   ├── index.ts
+│   │   ├── useComponentModifier.ts
+│   │   ├── useComponentThemeOverrides.ts
+│   │   ├── useDiscreteApi.ts
+│   │   ├── useInjection.ts
+│   │   ├── useResettable.ts
+│   │   └── useTheme.ts
+│   ├── injection/
+│   │   ├── index.ts
+│   │   └── interface.ts
+│   ├── layout/
+│   │   ├── aside/
+│   │   │   ├── SidebarMenu.vue
+│   │   │   ├── SidebarUserPanel.vue
+│   │   │   └── index.vue
+│   │   ├── footer/
+│   │   │   └── index.vue
+│   │   ├── header/
+│   │   │   ├── action/
+│   │   │   │   ├── AvatarDropdown.vue
+│   │   │   │   ├── FullScreen.vue
+│   │   │   │   ├── PreferencesDrawer.vue
+│   │   │   │   ├── SignOut.vue
+│   │   │   │   ├── ThemeModePopover.vue
+│   │   │   │   ├── component/
+│   │   │   │   └── index.vue
+│   │   │   ├── index.vue
+│   │   │   ├── logo/
+│   │   │   │   └── index.vue
+│   │   │   └── navigation/
+│   │   │       ├── Breadcrumb.vue
+│   │   │       ├── HorizontalMenu.vue
+│   │   │       ├── NavigationButton.vue
+│   │   │       └── index.vue
+│   │   ├── index.vue
+│   │   ├── main/
+│   │   │   └── index.vue
+│   │   ├── mobile/
+│   │   │   ├── MobileHeader.vue
+│   │   │   ├── MobileLeftAside.vue
+│   │   │   └── MobileRightAside.vue
+│   │   └── tabs/
+│   │       └── index.vue
+│   ├── main.ts
+│   ├── router/
+│   │   ├── guard.ts
+│   │   ├── helper.ts
+│   │   ├── index.ts
+│   │   └── record.ts
+│   ├── stores/
+│   │   ├── index.ts
+│   │   ├── preferences.ts
+│   │   ├── system.ts
+│   │   ├── tabs.ts
+│   │   └── user.ts
+│   ├── theme/
+│   │   ├── common.ts
+│   │   ├── dark.ts
+│   │   └── light.ts
+│   ├── types/
+│   │   ├── env.d.ts
+│   │   ├── vue-router.d.ts
+│   │   └── window.d.ts
+│   ├── utils/
+│   │   ├── chromaHelper.ts
+│   │   ├── tailwindColor.test.ts
+│   │   └── tailwindColor.ts
+│   └── views/
+│       ├── about/
+│       │   ├── dir.txt
+│       │   └── index.vue
+│       ├── dashboard/
+│       │   └── index.vue
+│       ├── data-show/
+│       │   ├── data-form/
+│       │   │   └── index.vue
+│       │   └── data-table/
+│       │       ├── ActionModal.vue
+│       │       └── index.vue
+│       ├── drag-drop/
+│       │   └── index.vue
+│       ├── dynamic-route/
+│       │   └── index.vue
+│       ├── error-page/
+│       │   ├── 404.vue
+│       │   └── index.vue
+│       ├── feedback/
+│       │   ├── discreteApi.ts
+│       │   └── index.vue
+│       ├── multi-level-menu/
+│       │   └── index.vue
+│       └── sign-in/
+│           ├── component/
+│           │   ├── Illustration1.vue
+│           │   ├── Illustration2.vue
+│           │   ├── Illustration3.vue
+│           │   └── ThemeColorPopover.vue
+│           └── index.vue
+├── tailwind.config.ts
+├── tsconfig.app.json
+├── tsconfig.json
+├── tsconfig.node.json
+├── tsconfig.vitest.json
+├── vercel.json
+├── vite.config.ts
+└── vitest.config.ts

--- a/src/views/about/index.vue
+++ b/src/views/about/index.vue
@@ -7,6 +7,8 @@ import { ScrollContainer } from '@/components'
 import { useInjection } from '@/composables'
 import { mediaQueryInjectionKey } from '@/injection'
 
+import directories from './dir.txt?raw'
+
 defineOptions({
   name: 'About',
 })
@@ -23,159 +25,6 @@ const directoryStructureHighlight = ref('')
 const dependenciesCodeHighlight = ref('')
 const devDependenciesCodeHighlight = ref('')
 
-const dir = ` 📂 lithe-admin
-├── 📄 README.en_US.md
-├── 📄 README.md
-├── 📄 eslint.config.ts
-├── 📄 index.html
-├── 📄 package.json
-├── 📄 pnpm-lock.yaml
-└── 📂 public/
-│  └── 📂 assets/
-│    ├── 📄 preloader.css
-│  ├── 📄 favicon.ico
-└── 📂 src/
-│  ├── 📄 App.vue
-│  └── 📂 assets/
-│    ├── 📄 base.css
-│    ├── 📄 main.css
-│    ├── 📄 noise.png
-│    ├── 📄 texture.png
-│    ├── 📄 topography.svg
-│  └── 📂 components/
-│    ├── 📄 AppLogo.vue
-│    ├── 📄 Noise.vue
-│    ├── 📄 UserAvatar.vue
-│    ├── 📄 UserDropdown.vue
-│    └── 📂 button-animation/
-│      ├── 📄 ButtonAnimation.test.ts
-│      ├── 📄 ButtonAnimation.vue
-│      ├── 📄 ButtonAnimationProvider.vue
-│      ├── 📄 index.ts
-│      ├── 📄 injection.ts
-│      ├── 📄 interface.ts
-│    └── 📂 collapse-transition/
-│      ├── 📄 CollapseTransition.test.ts
-│      ├── 📄 CollapseTransition.vue
-│    └── 📂 empty-placeholder/
-│      ├── 📄 EmptyPlaceholder.test.ts
-│      ├── 📄 EmptyPlaceholder.vue
-│    └── 📂 hint-help/
-│      ├── 📄 HintHelp.test.ts
-│      ├── 📄 HintHelp.vue
-│    ├── 📄 index.ts
-│    └── 📂 scroll-container/
-│      ├── 📄 ScrollContainer.test.ts
-│      ├── 📄 ScrollContainer.vue
-│  └── 📂 composables/
-│    ├── 📄 index.ts
-│    ├── 📄 useComponentModifier.ts
-│    ├── 📄 useComponentThemeOverrides.ts
-│    ├── 📄 useDiscreteApi.ts
-│    ├── 📄 useInjection.ts
-│    ├── 📄 useResettable.ts
-│    ├── 📄 useTheme.ts
-│  └── 📂 injection/
-│    ├── 📄 index.ts
-│    ├── 📄 interface.ts
-│  └── 📂 layout/
-│    └── 📂 aside/
-│      ├── 📄 SidebarMenu.vue
-│      ├── 📄 SidebarUserPanel.vue
-│      ├── 📄 index.vue
-│    └── 📂 footer/
-│      ├── 📄 index.vue
-│    └── 📂 header/
-│      └── 📂 action/
-│        ├── 📄 AvatarDropdown.vue
-│        ├── 📄 FullScreen.vue
-│        ├── 📄 PreferencesDrawer.vue
-│        ├── 📄 SignOut.vue
-│        ├── 📄 ThemeModePopover.vue
-│        └── 📂 component/
-│          ├── 📄 LayoutThumbnail.vue
-│          ├── 📄 NoiseModal.vue
-│          ├── 📄 WatermarkModal.vue
-│        ├── 📄 index.vue
-│      ├── 📄 index.vue
-│      └── 📂 logo/
-│        ├── 📄 index.vue
-│      └── 📂 navigation/
-│        ├── 📄 Breadcrumb.vue
-│        ├── 📄 HorizontalMenu.vue
-│        ├── 📄 NavigationButton.vue
-│        ├── 📄 index.vue
-│    ├── 📄 index.vue
-│    └── 📂 main/
-│      ├── 📄 index.vue
-│    └── 📂 mobile/
-│      ├── 📄 MobileHeader.vue
-│      ├── 📄 MobileLeftAside.vue
-│      ├── 📄 MobileRightAside.vue
-│    └── 📂 tabs/
-│      ├── 📄 index.vue
-│  ├── 📄 main.ts
-│  └── 📂 router/
-│    ├── 📄 guard.ts
-│    ├── 📄 helper.ts
-│    ├── 📄 index.ts
-│    ├── 📄 record.ts
-│  └── 📂 stores/
-│    ├── 📄 index.ts
-│    ├── 📄 preferences.ts
-│    ├── 📄 system.ts
-│    ├── 📄 tabs.ts
-│    ├── 📄 user.ts
-│  └── 📂 theme/
-│    ├── 📄 common.ts
-│    ├── 📄 dark.ts
-│    ├── 📄 light.ts
-│  └── 📂 types/
-│    ├── 📄 env.d.ts
-│    ├── 📄 vue-router.d.ts
-│    ├── 📄 window.d.ts
-│  └── 📂 utils/
-│    ├── 📄 chromaHelper.ts
-│    ├── 📄 tailwindColor.test.ts
-│    ├── 📄 tailwindColor.ts
-│  └── 📂 views/
-│    └── 📂 about/
-│      ├── 📄 index.vue
-│    └── 📂 dashboard/
-│      ├── 📄 index.vue
-│    └── 📂 data-show/
-│      └── 📂 data-form/
-│        ├── 📄 index.vue
-│      └── 📂 data-table/
-│        ├── 📄 ActionModal.vue
-│        ├── 📄 index.vue
-│    └── 📂 drag-drop/
-│      ├── 📄 index.vue
-│    └── 📂 dynamic-route/
-│      ├── 📄 index.vue
-│    └── 📂 error-page/
-│      ├── 📄 404.vue
-│      ├── 📄 index.vue
-│    └── 📂 feedback/
-│      ├── 📄 discreteApi.ts
-│      ├── 📄 index.vue
-│    └── 📂 multi-level-menu/
-│      ├── 📄 index.vue
-│    └── 📂 sign-in/
-│      └── 📂 component/
-│        ├── 📄 Illustration1.vue
-│        ├── 📄 Illustration2.vue
-│        ├── 📄 Illustration3.vue
-│        ├── 📄 ThemeColorPopover.vue
-│      ├── 📄 index.vue
-├── 📄 tailwind.config.ts
-├── 📄 tsconfig.app.json
-├── 📄 tsconfig.json
-├── 📄 tsconfig.node.json
-├── 📄 tsconfig.vitest.json
-├── 📄 vite.config.ts
-└── 📄 vitest.config.ts`
-
 onMounted(async () => {
   if (!codeToHtml) {
     // @ts-ignore
@@ -183,7 +32,7 @@ onMounted(async () => {
     codeToHtml = shiki.codeToHtml
   }
 
-  codeToHtml(dir, {
+  codeToHtml(directories, {
     lang: 'markdown',
     themes: {
       light: 'min-light',
@@ -191,7 +40,7 @@ onMounted(async () => {
     },
   })
     .then((result: string) => (directoryStructureHighlight.value = result))
-    .catch(() => (directoryStructureHighlight.value = dir))
+    .catch(() => (directoryStructureHighlight.value = directories))
 
   codeToHtml(JSON.stringify(dependencies, null, 2), {
     lang: 'json',


### PR DESCRIPTION
# 添加了一个新功能:```关于项目```页面项目自动生成目录结构
目前的依赖信息是通过package.json读取的，因此可以实时变动，但是是在代码里写死的，因此改成通过文本文件读取，文本文件的生成使用了tree-node-cli工具保证跨平台的可用性，基于同样的原因考虑，为了保证最大的兼容性没有使用```pnpm dlx```而是使用了```npx --yes```静默安装tree-node-cli并输出对应的目录结构，默认采用以下规则生成:

- 输出所有的文件，包括.开头文件，除非文件在以下目录下:

  - node_modules
  - dist
  - .git
  - .DS_Store
  - .output
  - .idea
  - .vscode

- 默认最大深度为5
- 如果是文件夹，会添加一个后缀/
- 最终输出到目录```src/views/about/dir.txt```

**注意**
基于跨平台的角度考虑没有进行 进一步处理，比如通过sed加上emoji表情 📃和📁来标明是文件还是文件夹

## 使用
可以有以下几种实用方式:
- 整合进build脚本
```json
"scripts": {
    "build": "run-p type-check tree \"build-only {@}\" --",
    // other scripts
}
```
- 直接运行
```bash
npm run tree
```