### PR TITLE
enable engine-strict to prevent dependency installation when the node version does not match

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
也可以额外配置以下属性:

```
# 使用npm镜像地址
registry=https://registry.npmmirror.com/
# 使用精确版本
save-exact=true
# 禁止生成 lock 文件
package-lock=false
# 启用engine-strict,Node 版本不符时禁止安装依赖
engine-strict=true
```

只使用了一个对已有系统影响最小的